### PR TITLE
Add `moo render-deps` command to create `.d` files for build systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ CMakeCache.txt
 CMakeFiles
 *.moved
 notes.org
+buildsys/make/model-dump.txt.d

--- a/buildsys.org
+++ b/buildsys.org
@@ -491,8 +491,7 @@ Waf: Leaving directory `/home/bv/dev/moo/buildsys/waf/mod/build'
    :CUSTOM_ID: make
    :END:
 
-Ah, venerable ~make~.  This example currently does not capture
-intermediate dependencies.  Contributions/fixes welcome.
+Ah, venerable ~make~.  We use ~moo render-deps~ to capture intermediate dependencies.
 
 
 The ~Makefile~:
@@ -506,7 +505,9 @@ And it getting exercised:
   make clean
   sed -i 's/fortran/FORTRAN/' sub/sub.jsonnet
   make
-  echo -e '\nNext we edit the intermediate files and note no rebuild\n'
+  echo -e '\nA second build without changes does nothing\n'
+  make
+  echo -e '\nNext we edit the intermediate files and note that we see a rebuild\n'
   sed -i 's/FORTRAN/fortran/' sub/sub.jsonnet
   make
   echo -e '\nIn any case, first build gave us:\n'
@@ -539,8 +540,10 @@ subsub = {'a': 1, 'b': 2, 'c': 'hello', 'd': 'FORTRAN'}
 
 This section describes one way to integrate ~moo~ with a CMake-based
 build.  It shows what one must do to insert a code generator into the
-build graph in a way that respects intermediate dependencies using ~moo
-imports~ like the [[Waf]] examples.  
+build graph in a way that respects intermediate dependencies using
+~moo imports~ like the [[Waf]] examples. If using the ~ninja~ generator
+(or CMake >3.20 with the Makefile generator), another method using
+~moo render-deps~ is available, described below
 
 #+begin_note
 Currently the CMake code is provided merely as an example which is
@@ -640,6 +643,45 @@ Update new implicit dependency, which should cause a rebuild
 -rw-rw-r-- 1 bv bv 93 2020-11-25 17:39:57.200332410 -0500 build/model-dump.txt
 #+end_example
 
+
+With the ~ninja~ backend, we can use ~moo render-deps~ as follows:
+
+#+include: buildsys/cmake-deps-ninja/CMakeLists.txt src cmake
+
+And, here it is getting exercised:
+
+#+begin_src shell :exports both :results output code :wrap "example"
+  cd buildsys/cmake-deps-ninja
+  rm -rf build
+  echo '{a:1,b:2,c:"hello"}' > sub.jsonnet
+  cmake -B build -S . -G Ninja
+
+  echo -e '\nDo initial build\n'
+  sed -i 's/fortran/FORTRAN/' sub/sub.jsonnet
+  cmake --build build
+  ls -l --full-time build/model-dump.txt
+
+  echo -e '\nNext we edit the intermediate files and notice a rebuild\n'
+  sed -i 's/FORTRAN/fortran/' sub/sub.jsonnet
+  cmake --build build
+  ls -l --full-time build/model-dump.txt
+
+  echo -e '\nDo do a second build, output is not rebuilt\n'
+  cmake --build build
+  ls -l --full-time build/model-dump.txt
+
+  echo -e '\nAdd new implicit dependency, which should cause a rebuild\n'
+  echo -e 'local ss = import "sub/sub2.jsonnet";\nss' > sub.jsonnet
+  echo '{a:1,b:2,c:"hello"}' > sub/sub2.jsonnet
+  cmake --build build
+  ls -l --full-time build/model-dump.txt
+
+  echo -e '\nUpdate new implicit dependency, which should cause a rebuild\n'
+  echo '{a:1,b:2,c:"see me"}' > sub/sub2.jsonnet
+  cmake --build build
+  ls -l --full-time build/model-dump.txt
+
+#+end_src
 
 
 

--- a/buildsys/cmake-deps-ninja/CMakeLists.txt
+++ b/buildsys/cmake-deps-ninja/CMakeLists.txt
@@ -1,0 +1,13 @@
+project("moo-buildsys-cmake-deps")
+cmake_minimum_required(VERSION 3.7...3.17) # Need 3.7 for DEPFILE in add_custom_command()
+
+# fixme: needs to turn into a find_package(moo)!
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+include(moo)
+
+moo_codegen(MODEL model.jsonnet TEMPL dump.txt.j2 CODEGEN model-dump.txt)
+
+## We need some target to trigger the codegen.  Normally, this would
+## be done by some "real" code target depending on the CODEGEN output.
+##   cmake --build build/ -t DOIT
+add_custom_target(DOIT ALL DEPENDS model-dump.txt)

--- a/buildsys/cmake-deps-ninja/dump.txt.j2
+++ b/buildsys/cmake-deps-ninja/dump.txt.j2
@@ -1,0 +1,3 @@
+{% for k,v in model.items() %}
+{{k}} = {{v}}
+{% endfor %}

--- a/buildsys/cmake-deps-ninja/model.jsonnet
+++ b/buildsys/cmake-deps-ninja/model.jsonnet
@@ -1,0 +1,3 @@
+local sub = import "sub.jsonnet";
+local subsub = import "sub/sub.jsonnet";
+{ sub: sub, subsub: subsub }

--- a/buildsys/cmake-deps-ninja/moo.cmake
+++ b/buildsys/cmake-deps-ninja/moo.cmake
@@ -1,0 +1,38 @@
+# fixme: move into find_package(moo)!
+# For now, use eg cmake -DMOO_CMD=$(which moo)
+set(MOO_CMD "moo" CACHE STRING "The 'moo' command")
+
+macro(moo_codegen)
+  cmake_parse_arguments(MC "" "MODEL;TEMPL;CODEGEN;MPATH;TPATH;GRAFT;TLAS" "" ${ARGN})
+
+  if (NOT DEFINED MC_MPATH)
+    set(MC_MPATH ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+  if (NOT DEFINED MC_TPATH)
+    set(MC_TPATH ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  list(TRANSFORM $MC_GRAFT APPEND "-g")
+  list(TRANSFORM $MC_TLAS APPEND "-A")
+  set(MC_BASE_ARGS -T ${MC_TPATH} -M ${MC_MPATH} ${MC_GRAFT} ${MC_TLAS})
+
+  set(MC_MODEL_DEPS_ARGS ${MC_BASE_ARGS} imports -o ${MC_MODEL_DEPS_FILE} ${MC_MODEL})
+  #message("model deps args ${MC_MODEL_DEPS_ARGS}")
+
+  set(MC_TEMPL_DEPS_ARGS ${MC_BASE_ARGS} imports -o ${MC_TEMPL_DEPS_FILE} ${MC_TEMPL})
+
+  set(MC_DEPS_FILE ${MC_CODEGEN}.d)
+  set(MC_CODEGEN_ARGS ${MC_BASE_ARGS} render -o ${MC_CODEGEN} ${MC_MODEL} ${MC_TEMPL})
+  set(MC_RENDER_DEPS_ARGS ${MC_BASE_ARGS} render-deps -o ${MC_DEPS_FILE} -t ${MC_CODEGEN} ${MC_MODEL} ${MC_TEMPL})
+  
+  message("codegen args ${MC_CODEGEN_ARGS}")
+  add_custom_command(
+    COMMAND ${MOO_CMD} ARGS ${MC_CODEGEN_ARGS}
+    COMMAND ${MOO_CMD} ARGS ${MC_RENDER_DEPS_ARGS}
+    COMMENT "generate code ${MC_CODEGEN}"
+    DEPENDS "${MC_MODEL}" "${MC_TEMPL}"
+    DEPFILE ${MC_DEPS_FILE}
+    OUTPUT "${MC_CODEGEN}")
+
+endmacro()
+

--- a/buildsys/cmake-deps-ninja/sub.jsonnet
+++ b/buildsys/cmake-deps-ninja/sub.jsonnet
@@ -1,0 +1,1 @@
+{a:1,b:2,c:"hello",d:"fortran"}

--- a/buildsys/cmake-deps-ninja/sub/sub.jsonnet
+++ b/buildsys/cmake-deps-ninja/sub/sub.jsonnet
@@ -1,0 +1,1 @@
+{a:1,b:2,c:"hello",d:"fortran"}

--- a/buildsys/make/Makefile
+++ b/buildsys/make/Makefile
@@ -1,4 +1,18 @@
-model-dump.txt : model.jsonnet dump.txt.j2 
-	moo render -o $@ $^
+# The automatic dependency technique here is simplified from
+# http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
+all: model-dump.txt
+
+model-dump.txt : model.jsonnet dump.txt.j2 model-dump.txt.d
+	moo render-deps -t $@ -o model-dump.txt.d model.jsonnet dump.txt.j2
+	moo render -o $@ model.jsonnet dump.txt.j2
+
+model-dump.txt.d: ;
+
 clean:
-	rm -f model-dump.txt
+	rm -f model-dump.txt model-dump.txt.d
+
+.PHONY: clean all
+
+# The apparently-superfluous use of "wildcard" here prevents a warning
+# on the first build that model-dump.txt.d doesn't exist
+include $(wildcard model-dump.txt.d)

--- a/moo/__main__.py
+++ b/moo/__main__.py
@@ -306,17 +306,29 @@ def dump(ctx, output, format, model):
 @click.option('-o', '--output', default="/dev/stdout",
               type=click.Path(exists=False, dir_okay=False, file_okay=True),
               help="Output file, default is stdout")
+@click.option('-d', '--depend', default=None,
+              type=click.Path(exists=False, dir_okay=False, file_okay=True),
+              help="Output file of dependencies, a la gcc -MD")
 @click.argument('model')
 @click.argument('templ')
 @click.pass_context
-def render(ctx, output, model, templ):
+def render(ctx, output, depend, model, templ):
     '''
     Render a template against a model.
     '''
     data = ctx.obj.load(model)
     text = ctx.obj.render(templ, data)
     ctx.obj.save(output, text)
+    
+    if depend:
+        model_deps = ctx.obj.imports(model)
+        templ_deps = ctx.obj.imports(templ)
+        deps_string = f'{output}: '
+        deps_string += " ".join(templ_deps)
+        deps_string += " "
+        deps_string += " ".join(model_deps)
 
+        ctx.obj.save(depend, deps_string)
 
 @cli.command('render-many')
 @click.option('-o', '--outdir', default=".",

--- a/moo/__main__.py
+++ b/moo/__main__.py
@@ -306,29 +306,49 @@ def dump(ctx, output, format, model):
 @click.option('-o', '--output', default="/dev/stdout",
               type=click.Path(exists=False, dir_okay=False, file_okay=True),
               help="Output file, default is stdout")
-@click.option('-d', '--depend', default=None,
-              type=click.Path(exists=False, dir_okay=False, file_okay=True),
-              help="Output file of dependencies, a la gcc -MD")
 @click.argument('model')
 @click.argument('templ')
 @click.pass_context
-def render(ctx, output, depend, model, templ):
+def render(ctx, output, model, templ):
     '''
     Render a template against a model.
     '''
     data = ctx.obj.load(model)
     text = ctx.obj.render(templ, data)
     ctx.obj.save(output, text)
-    
-    if depend:
-        model_deps = ctx.obj.imports(model)
-        templ_deps = ctx.obj.imports(templ)
-        deps_string = f'{output}: '
-        deps_string += " ".join(templ_deps)
-        deps_string += " "
-        deps_string += " ".join(model_deps)
 
-        ctx.obj.save(depend, deps_string)
+@cli.command('render-deps')
+@click.option('-t', '--target', required=True,
+              type=click.Path(exists=False, dir_okay=False, file_okay=True),
+              help="Name of target in the .d file")
+@click.option('-o', '--output', default="/dev/stdout",
+              type=click.Path(exists=False, dir_okay=False, file_okay=True),
+              help="Dependency output file, default is stdout")
+@click.argument('model')
+@click.argument('templ')
+@click.pass_context
+def render_deps(ctx, target, output, model, templ):
+    '''Produce a .d dependencies file for the corresponding call to "render"
+
+    Produce a .d dependencies file in the style of `gcc -MD` to be
+    used by a build system (Makefile or ninja), corresponding to a
+    call to "moo render". The arguments to "moo render-deps" should be
+    the same as the arguments to the corresponding call to "moo
+    render", with the following exceptions:
+
+    * The -t option to "moo render-deps" is typically taken from the -o option to "moo render"
+    * The -o option to "moo render-deps" is the name of the .d file that should be output
+
+    '''
+    model_deps = ctx.obj.imports(model)
+    templ_deps = ctx.obj.imports(templ)
+    deps_string = f'{target}: '
+    deps_string += " ".join(templ_deps)
+    deps_string += " "
+    deps_string += " ".join(model_deps)
+    deps_string += "\n"
+    ctx.obj.save(output, deps_string)
+
 
 @cli.command('render-many')
 @click.option('-o', '--outdir', default=".",
@@ -366,7 +386,7 @@ def imports(ctx, output, filename):
     Emit a list of imports required by the model
     '''
     deps = ctx.obj.imports(filename)
-    if output.endswith(".cmake"):  # special output format
+    if output.endswith(".cmake"):  # special output format, cmake
         basename = os.path.splitext(os.path.basename(output))[0]
         varname = re.sub("[^a-zA-Z0-9]", "_", basename).upper()
         lines = [f'set({varname}']


### PR DESCRIPTION
This PR adds a `moo render-deps` command that creates a `.d` file containing Makefile-style dependencies. The typical use is to use `moo render-deps` in conjunction with a `moo render` command: the render command creates an output file, while the render-deps command creates the `.d` file that describes the dependencies of that output file.

Also included are examples of how to use the generated `.d` file with a Makefile-based build and a CMake build. The CMake build requires the ninja backed generator. It looks like CMake 3.20 will be out soon, with support for using the `.d` files with the Makefile backend.