### PR TITLE
Update for jsonschema v3.2.0

### DIFF
--- a/moo/jsonnet-code/schema/re.jsonnet
+++ b/moo/jsonnet-code/schema/re.jsonnet
@@ -4,19 +4,19 @@
     ident: '[a-zA-Z][a-zA-Z0-9_]*',
     ident_only: '^' + self.ident + '$',
     // DNS hostname
-    ipv4: '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}',
-    dnslabel: '[a-zA-Z0-9]([a-zA-Z0-9\\-]*[a-zA-Z0-9])?',
-    dnshost: '%s(\\.%s)*' % [self.dnslabel, self.dnslabel],
+    ipv4: '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}',
+    dnslabel: '[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?',
+    dnshost: '%s(.%s)*' % [self.dnslabel, self.dnslabel],
 
     tcpport: '(:[0-9]+)?',
 
     // a slash-separated list/path like FS paths
     // fixme: this is maybe too accepting
-    hiername: '[a-zA-Z0-9.]([a-zA-Z0-9._+\\-])?',
+    hiername: '[a-zA-Z0-9.]([a-zA-Z0-9._+-])?',
     hierpath: '/?(%s/?)+' % self.hiername,
     // a dot-separated list/path list Python modules
     dotname: self.ident,
-    dotpath: '%s(\\.%s)*' % [self.dotname, self.dotname],
+    dotpath: '%s(.%s)*' % [self.dotname, self.dotname],
 
     // thing specific to zmq
     zmq: {
@@ -36,7 +36,7 @@
 
         uri_list : [self.tcp.uri, self.ipc.uri, self.inproc.uri],
         uri: '(%s)' % std.join('|',['(%s)'%one for one in self.uri_list]),
-        
+
         socket: {
             name_list: [
                 "PAIR", "PUB", "SUB", "REQ", "REP", "DEALER", "ROUTER",
@@ -65,4 +65,4 @@
     compname: self.ident,
     // match a "typename" for a component
     comptype: self.ident,
-}    
+}

--- a/moo/jsonschema.py
+++ b/moo/jsonschema.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 from .util import unflatten, pathify
 
-# We 'borrow' jsonschema exception as our own 
+# We 'borrow' jsonschema exception as our own
 from jsonschema.exceptions import ValidationError
 
 import jsonschema
-format_checker = jsonschema.Draft7Validator.FORMAT_CHECKER
+# Deprecated:
+# https://python-jsonschema.readthedocs.io/en/stable/api/jsonschema/protocols/#jsonschema.protocols.Validator.FORMAT_CHECKER
+# format_checker = jsonschema.Draft7Validator.FORMAT_CHECKER
+
+
 
 def ref(oschema):
     '''
@@ -73,7 +77,7 @@ def field(f):
           "title": name[0].upper() + name[1:].replace("_", " "),
           "description": "%s (type: %s)" % (f.get("doc",''), item.split(".")[-1])}
     return js
-    
+
 
 def record(r):
     '''
@@ -82,7 +86,7 @@ def record(r):
     js = dict(type='object',
               properties = { f["name"]: field(f) for f in r["fields"] })
     return js
-    
+
 
 def enum(e):
     return {type: "string", enum: e['symbols']}
@@ -103,7 +107,7 @@ def typify(o):
     tn = o["schema"]
     return globals()[tn](o)
 
-    
+
 def get_all_deps(flat, deps):
     ret = set(deps)
     for dep in deps:
@@ -120,7 +124,7 @@ def convert(target, context=None, id=None):
     Convert a target moo oschema in a moo schema context to a JSON Schema form or pass through JSON Schema.
 
     @param target:the moo schema to form the top-level JSON Schema or an already made JSON Schema
-    
+
     @param context:a sequence or object with values that of individual moo schema.
 
     """
@@ -140,7 +144,7 @@ def convert(target, context=None, id=None):
     last = typify(target)
     js.update(last)
     return js
-     
+
 def make_validator_jsonschema():
     '''
     Return a generic looking validator using jsonschema
@@ -149,8 +153,7 @@ def make_validator_jsonschema():
     from jsonschema import validate as js_validate
     def validate(model, schema={}):
         try:
-            return js_validate(instance=model, schema=schema,
-                               format_checker=format_checker)
+            return js_validate(instance=model, schema=schema)#,format_checker=format_checker)
         except SchemaError as err:
             raise ValidationError('invalid') from err
     return validate

--- a/moo/otypes.py
+++ b/moo/otypes.py
@@ -374,11 +374,10 @@ class _String(BaseType):
         if ost["format"]:
             schema["format"] = ost["format"]
         from jsonschema import validate as js_validate
-        from .jsonschema import format_checker
+        #from .jsonschema import format_checker
         from jsonschema.exceptions import ValidationError
         try:
-            js_validate(instance=val, schema=schema,
-                        format_checker=format_checker)
+            js_validate(instance=val, schema=schema) #,format_checker=format_checker)
         except ValidationError as verr:
             raise ValueError(f'format mismatch for string {cname}') from verr
         self._value = val
@@ -515,17 +514,17 @@ class _Number(BaseType):
             if emaxi is not None:
                 if not v < emaxi:
                    raise ValueError(f'illegal {cname} number {v} not strictly less than {emaxi}')
-               
+
             emini = nc.get("exclusiveMinimum", None)
             if emini is not None:
                 if not v > emini:
                    raise ValueError(f'illegal {cname} number {v} not strictly greater than {emini}')
-               
+
             maxi = nc.get("maximum", None)
             if maxi is not None:
                 if not v <= maxi:
                    raise ValueError(f'illegal {cname} number {v} not less than or equal {maxi}')
-               
+
             mini = nc.get("minimum", None)
             if mini is not None:
                 if not v >= mini:
@@ -671,7 +670,7 @@ def make_type(**ost):
 
 
 def make_types(schema):
-    '''Make Python types from a schema structure.  
+    '''Make Python types from a schema structure.
 
     The schema should be in the form of an array of oschema type
     structures.


### PR DESCRIPTION
The latest moo version doesn't work with `jsonschema==3.2.0`, which the DAQ uses. We now have `go` in the sw stack, and it'd be very interesting to use `gojsonnet` rather than what we have now (>4 fold speed increase in python) for `{fd,nd}daqconf`.

I've commented out the offending lines. I'm not actually sure what this should be.

I've also changed the regexes and removed the escaping of `.` and `-` chars.

I'm not sure if I have broken anything.